### PR TITLE
Fix tree traverse strategy

### DIFF
--- a/pynguin_0_41_0/src/pynguin/custom_seeding/strategy/tree_traverse_strategy.py
+++ b/pynguin_0_41_0/src/pynguin/custom_seeding/strategy/tree_traverse_strategy.py
@@ -125,7 +125,7 @@ class TreeTraverseStrategy(BaseStrategy):
             self,
             left: NodeNG,
             right: NodeNG,
-    ) -> tuple[list[str] | str, bool, bool]:
+    ) -> tuple[list[str] | str, str, bool, bool]:
         """Extracts values from a compare operation.
 
         Checks if the left and right nodes are parameter and constant.
@@ -134,6 +134,7 @@ class TreeTraverseStrategy(BaseStrategy):
 
         Returns a tuple containing:
         - The value(s) as a string or list of strings.
+        - The name of the parameter.
         - A boolean indicating if the value is a single string.
         - A boolean indicating if the left node is the parameter.
         """
@@ -153,7 +154,7 @@ class TreeTraverseStrategy(BaseStrategy):
 
         # If neither left nor right is a parameter, we cannot extract values
         if not (is_parameter_in or is_in_parameter):
-            return [], False, param_left
+            return [], "", False, param_left
 
         # Switch parameter to left for value extraction
         if is_in_parameter:
@@ -161,7 +162,7 @@ class TreeTraverseStrategy(BaseStrategy):
             param_left = False
 
         value, is_single = TreeTraverseStrategy._extract_literal_repr(right)
-        return value, is_single, param_left
+        return value, left.name, is_single, param_left
 
     @staticmethod
     def _handle_compare_operation_cases(
@@ -214,7 +215,7 @@ class TreeTraverseStrategy(BaseStrategy):
                 left = node.left
                 right = comparator
 
-                value, is_single, param_left = self._get_compare_values(left, right)
+                value, param_name, is_single, param_left = self._get_compare_values(left, right)
 
                 if not value:
                     logger.debug(
@@ -226,7 +227,7 @@ class TreeTraverseStrategy(BaseStrategy):
                 # Used set instead of list, as Python optimize set membership tests
                 if op in {"not in", "in"}:
                     current_state = self._handle_compare_operation_cases(
-                        param_name=left.name,
+                        param_name=param_name,
                         value=value,
                         is_single=is_single,
                         param_left=param_left,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ipykernel==6.29.5
 coverage==7.8.2
 ruff==0.12.1
 pydantic-settings==2.9.1
+numpy==2.2.6

--- a/scripts/examples/mixed_with_len_func/in_n_len.py
+++ b/scripts/examples/mixed_with_len_func/in_n_len.py
@@ -1,5 +1,5 @@
 """Tests behaviour when a substring matches a specific value and its length exceeds 10."""
-def strComp_n_len(param: str) -> bool:
+def in_n_len(param: str) -> bool:
     if (not param in "Software Engineering 1" and param in "Software Engineering 123") and len(param) > 10:  # noqa: E713
         return True
     return False

--- a/scripts/examples/mixed_with_len_func/in_n_len2.py
+++ b/scripts/examples/mixed_with_len_func/in_n_len2.py
@@ -1,5 +1,5 @@
 """Tests behaviour of substring matching with different length conditions on both inputs."""
-def strComp_n_len2(param1: str, param2: str) -> bool:
+def in_n_len2(param1: str, param2: str) -> bool:
     if ("Hello world and universe!" in param1 and "Goodbye everyone." in param2) and (len(param1) < len(param2)):
         return True
     return False

--- a/scripts/examples/mixed_with_len_func/str_comp_n_len.py
+++ b/scripts/examples/mixed_with_len_func/str_comp_n_len.py
@@ -1,7 +1,7 @@
 """Tests behaviour when the first parameter equals one of two values using or,
 has length modulo 3 equal to 2, and the second parameter is different from a forbidden value
 and has length greater than 8."""
-def strComp_n_len3(param1: str, param2: str) -> bool:    
+def str_comp_n_len(param1: str, param2: str) -> bool:    
     if ((param1 == "Software Engineering 1" or param1 == "Software Engineering 2")
         and len(param1) % 3 == 2) and (param2 != "forbidden" and len(param2) > 8):
         return True

--- a/scripts/examples/mixed_with_len_func/str_comp_n_len2.py
+++ b/scripts/examples/mixed_with_len_func/str_comp_n_len2.py
@@ -1,5 +1,5 @@
 """Tests behaviour based on disjunctive and nested conditions involving string equality and length constraints."""
-def strComp_n_len4(param1: str, param2: str, param3: str) -> bool:    
+def str_comp_n_len2(param1: str, param2: str, param3: str) -> bool:    
     if param1 == "Prime number" or len(param2) == 17:
         if param3 == "Fibonacci" or len(param3) != 11:
             if param2 == "Euler's number" or len(param1) > 23:                        


### PR DESCRIPTION
I realised a logic error in my "param in str" and "param in list" handling, as it ignored in the following case the param2:

```text
if param1 in "hello":
     if param2 in "lower":
```

Same for:

```text
if param1 in "hello":
     if param2 in ["lower", "upper"]:
```

Also I did the naming of `append_in_str` and `append_str_in` the other way around.

Also fixed missing import after removal of fuzzing book (found by accident)